### PR TITLE
Voms 891

### DIFF
--- a/src/VOMSAdmin/VOMSCommands.py
+++ b/src/VOMSAdmin/VOMSCommands.py
@@ -548,7 +548,11 @@ class VOMSAdminProxy:
     def __printUserList(self, user_list):
         for u in user_list:
 
-            cert = "%s,%s" %(u['certificates'][0]['subjectString'],u['certificates'][0]['issuerString'])
+            if not len(u['certificates']) or len(u['certificates']) == 0:
+                cert = "No certificates defined for this user."
+
+            else:
+                cert = "%s,%s" %(u['certificates'][0]['subjectString'],u['certificates'][0]['issuerString'])
 
             if u['suspended']:
                 status = "Suspended: %s" % u['suspensionReason']
@@ -562,6 +566,29 @@ class VOMSAdminProxy:
 
             email = u['emailAddress']
             print "%s,%s,%s,%s" % (cert, status, name, email)
+
+    def __printMultipleCertificatesList(self, user_list):
+        for u in user_list:
+
+
+            for c in range(len(u['certificates']) if len(u['certificates']) else 1):
+                if not len(u['certificates']) or len(u['certificates']) == 0:
+                    cert = "No certificates defined for this user."
+                else:
+                    cert = "%s,%s" %(u['certificates'][c]['subjectString'],u['certificates'][c]['issuerString'])
+
+                if u['suspended']:
+                    status = "Suspended: %s" % u['suspensionReason']
+                else:
+                    status = "Active"
+
+                if u['name'] != None and u['surname'] != None:
+                    name = "%s %s (%d)" % (u['name'], u['surname'], u['id'])
+                else:
+                    name = ""
+
+                email = u['emailAddress']
+                print "%s,%s,%s,%s" % (cert, status, name, email)
 
     def __handleCallReturnValue(self, ret_val):
         if ret_val is None:
@@ -609,6 +636,10 @@ class VOMSAdminProxy:
         res = self.__getUserStats()
         print "Expired user count: %d" % res['expiredUsersCount']
 
+    def countAllSuspendedCertificates(self):                                           
+        res = self.__getSuspendedUsers()
+        print "All Suspended certificates count: %d" % res['suspendedUsersCount']
+
     def listAUPFailingUsers(self):
         res = self._getAUPFailingUsers()
         if len(res['aupFailingUsers']) == 0:
@@ -622,6 +653,13 @@ class VOMSAdminProxy:
             print "No suspended users found."
         else:
             self.__printUserList(res['suspendedUsers'])
+
+    def listAllSuspendedCertificates(self):                                   
+        res = self.__getSuspendedUsers()
+        if len(res['suspendedUsers']) == 0:
+            print "No suspended users found."
+        else:
+            self.__printMultipleCertificatesList({res['suspendedUsers'])
 
     def listExpiredUsers(self):
         res = self.__getExpiredUsers()

--- a/src/VOMSAdmin/VOMSCommandsDef.py
+++ b/src/VOMSAdmin/VOMSCommandsDef.py
@@ -62,6 +62,7 @@ commands_def="""<?xml version="1.0" encoding="UTF-8"?>
         xml:space="preserve">
         Counts how many VO users are currently suspended. (Requires VOMS Admin server >= 2.7.0)</help-string>
     </command>
+
     <command
       name="count-users">
       <description>count-users</description>
@@ -857,5 +858,22 @@ commands_def="""<?xml version="1.0" encoding="UTF-8"?>
         <arg
             type="User"/>
       </command>
+
+      <command
+        name="list-all-suspended-certificates">
+        <description>list-all-suspended-certificates</description>
+        <help-string
+          xml:space="preserve">
+          Lists all certificates in the VO users that are currently suspended. (Requires VOMS Admin server >= 2.7.0)</help-string>
+      </command>
+
+      <command
+        name="count-all-suspended-certificates">
+        <description>count-all-suspended-certificates</description>
+        <help-string
+          xml:space="preserve">
+          Counts how many certificates in the VO users are currently suspended. (Requires VOMS Admin server >= 2.7.0)</help-string>
+      </command>
+
   </command-group>
 </voms-commands>"""

--- a/src/voms-admin
+++ b/src/voms-admin
@@ -239,10 +239,10 @@ def execute_command(cmd):
 
     if isinstance(res, types.ListType):
         for i in res:
-            print unicode(i)
+            print unicode(str(i),'utf-8')
     else:
         if not res is None:
-            print unicode(res)
+            print unicode(str(res),'utf-8')
 
 
 def local_endpoint_conf_path():


### PR DESCRIPTION
voms-admin list-suspended-users only shows one suspended certificate

     - fixed user without certificate bug.
     - added feature to count all suspended certificates
       (count-all-suspended-certificates)
     - added feature to list all suspended certificate for users with
       miltiple suspended certificates (list-all-suspended-certificates)
    
    Fixes: https://issues.infn.it/jira/browse/VOMS-891
